### PR TITLE
volume controlled via scroll wheel

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -89,7 +89,7 @@ function createWindow() {
   }, 10);
 
   // Open the DevTools.
-  // mainWindow.webContents.openDevTools({mode:"detach"});
+  mainWindow.webContents.openDevTools({mode:"detach"});
 
   ipcMain.on('windowMoving', (e: Event, { mouseX, mouseY }: { mouseX: number, mouseY: number }) => {
     const { x, y } = screen.getCursorScreenPoint();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -89,7 +89,7 @@ function createWindow() {
   }, 10);
 
   // Open the DevTools.
-  mainWindow.webContents.openDevTools({mode:"detach"});
+  // mainWindow.webContents.openDevTools({mode:"detach"});
 
   ipcMain.on('windowMoving', (e: Event, { mouseX, mouseY }: { mouseX: number, mouseY: number }) => {
     const { x, y } = screen.getCursorScreenPoint();

--- a/src/renderer/components/Lofi/Cover/Controls/index.tsx
+++ b/src/renderer/components/Lofi/Cover/Controls/index.tsx
@@ -61,6 +61,7 @@ class Controls extends React.Component<any, any> {
         <a onClick={this.forward.bind(this)} className='control-btn secondary-control not-draggable skip'><i className="fa fa-step-forward not-draggable"></i></a>
         </p>
         <div className='progress' style={{width: this.props.parent.getTrackProgress() + '%'}}/>
+        <div className='volume' style={{height: this.props.parent.getVolume() + '%'}} />
       </div>
     );
   }

--- a/src/renderer/components/Lofi/Cover/Controls/style.scss
+++ b/src/renderer/components/Lofi/Cover/Controls/style.scss
@@ -61,10 +61,11 @@
     bottom: 0;
 }
 
-.pause-play {
-
-}
-
-.skip {
+.volume {
+    height: 100%;
+    background: #ffccf25c;
+    bottom: 0;
+    width: 2px;
+    position: absolute;
 
 }

--- a/src/renderer/components/Lofi/index.tsx
+++ b/src/renderer/components/Lofi/index.tsx
@@ -93,6 +93,7 @@ class Lofi extends React.Component<any, any> {
     let animationId: number;
     let mouseX: number;
     let mouseY: number;
+
     function onMouseDown(e: any) {
         if (leftMousePressed(e) && !e.target['classList'].contains('not-draggable')) {
             mouseX = e.clientX;  


### PR DESCRIPTION
This PR allows Spotify volume to be controlled via the scroll wheel when hovering over the main window. The volume control is a 2-px-wide bar on the left side of the Lofi window, as pictured below.

![Volume control](https://cdn.discordapp.com/attachments/513364427722981377/581933044496072716/volume.png)
