### PR TITLE
Made progress bars more discreet + timeout bugfix

### DIFF
--- a/src/renderer/components/Lofi/Cover/Controls/style.scss
+++ b/src/renderer/components/Lofi/Cover/Controls/style.scss
@@ -55,7 +55,7 @@
 }
 
 .progress {
-    height: 2px;
+    height: 1px;
     background: #ccffe15c;
     position: absolute;
     bottom: 0;
@@ -63,9 +63,9 @@
 
 .volume {
     height: 100%;
-    background: #ffccf25c;
-    bottom: 0;
-    width: 2px;
+    background: #ccffe15c;
+    bottom: 1px;
+    width: 1px;
     position: absolute;
 
 }

--- a/src/renderer/components/Lofi/Cover/index.tsx
+++ b/src/renderer/components/Lofi/Cover/index.tsx
@@ -131,6 +131,17 @@ class Cover extends React.Component<any, any> {
         await this.listeningTo();
       } else {
         const currently_playing = await res.json();
+        // Fixes https://github.com/dvx/lofi/issues/31
+        // The solution is a bit ugly: seek to current position so Spotify doesn't kill our current active_device
+        if (!currently_playing.is_playing) {
+          await fetch('https://api.spotify.com/v1/me/player/seek?position_ms=' + currently_playing.progress_ms, {
+            method: 'PUT',
+            headers: new Headers({
+              'Authorization': 'Bearer '+ this.props.token
+            })
+          });
+        }
+
         // console.log(currently_playing);
         this.setState({
           currently_playing


### PR DESCRIPTION
This PR fixes #31 and makes progress bars 1px instead of 2px, which looks a bit more in-line with Lofi's current aesthetic.