### PR TITLE
Fix track info hover flicker

### DIFF
--- a/src/renderer/components/Lofi/Cover/TrackInfo/style.scss
+++ b/src/renderer/components/Lofi/Cover/TrackInfo/style.scss
@@ -33,6 +33,7 @@
 .track-info {
     opacity: 0;
     font-size: 90%;
+    pointer-events: none;
 }
 
 .artist {


### PR DESCRIPTION
This PR fixes #34.

Only hovering over the 150x150 app area shows the track-info.


![lofi_flicker](https://user-images.githubusercontent.com/10602289/60636248-b6b59000-9de3-11e9-881f-fbcad678e06b.gif)