### PR TITLE
Settings Window Tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lofi",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Mini Spotify player with visualizations.",
   "homepage": "http://lofi.rocks",
   "main": "./pack/main.bundle.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,7 +30,7 @@ export const SETTINGS_CONTAINER = {
 };
 
 export const DEFAULT_SETTINGS = {
-  version: '1.5.0',
+  version: '1.5.1',
   debug: false,
   hardware_acceleration: true,
   lofi: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,6 +47,7 @@ export const DEFAULT_SETTINGS = {
     },
     audio: {
       volume_increment: 10,
+      display_volume_change: false,
     },
   },
   spotify: {

--- a/src/renderer/components/Lofi/Cover/Controls/index.tsx
+++ b/src/renderer/components/Lofi/Cover/Controls/index.tsx
@@ -53,6 +53,10 @@ class Controls extends React.Component<any, any> {
   }
 
   renderVolumeLabel() {
+    if (!this.props.parent.state.display_volume_change) {
+      return;
+    }
+
     const className = this.props.parent.state.volume_changed
       ? 'volume-number-show'
       : 'volume-number';

--- a/src/renderer/components/Lofi/Cover/index.tsx
+++ b/src/renderer/components/Lofi/Cover/index.tsx
@@ -37,6 +37,7 @@ class Cover extends React.Component<any, any> {
       volume: 0,
       volume_increment: DEFAULT_SETTINGS.lofi.audio.volume_increment,
       volume_changed: false,
+      display_volume_change: DEFAULT_SETTINGS.lofi.audio.display_volume_change,
       stateChange: new Date(1900, 1, 1),
       shuffle: null,
     };
@@ -51,15 +52,18 @@ class Cover extends React.Component<any, any> {
     this.setState({ intervalId });
 
     function onMouseWheel(e: WheelEvent) {
-      const volume_percent =
-        that.props.lofi.state.lofiSettings.audio.volume_increment / 100;
-      const new_volume = e.deltaY * volume_percent;
+      const volume_increment = that.props.lofi.state.lofiSettings.audio
+        ? that.props.lofi.state.lofiSettings.audio.volume_increment
+        : DEFAULT_SETTINGS.lofi.audio.volume_increment;
 
-      if (e.deltaY > 0 && that.state.volume > 0) {
-        that.setVolume(that.state.volume - new_volume);
-      } else if (e.deltaY < 0 && that.state.volume < 100) {
-        that.setVolume(that.state.volume + Math.abs(new_volume));
-      }
+      const volume_percent = volume_increment / 100;
+      const new_volume = _.clamp(
+        that.state.volume - e.deltaY * volume_percent,
+        0,
+        100
+      );
+
+      that.setVolume(new_volume);
     }
 
     document

--- a/src/renderer/components/Lofi/Settings/style.scss
+++ b/src/renderer/components/Lofi/Settings/style.scss
@@ -12,13 +12,16 @@
     padding-top: 0;
     font-feature-settings: normal;
     font-family: 'Inter UI', sans-serif;
+    height: calc(100% - 40px);
+    display: flex;
+    flex-direction: column;
   }
 
   fieldset {
     border-color: #717171;
     border-width: 2px;
   }
-  
+
   legend {
     font-size: 130%;
     color: rgb(214, 146, 255);
@@ -26,12 +29,12 @@
     font-variant: all-petite-caps;
     text-shadow: #00000085 0px 0px 4px;
   }
-  
+
   .control-label {
     color: rgb(212, 212, 212);
     font-weight: 400;
   }
-  
+
   .picker {
     display: block;
     font-size: 12px !important;
@@ -49,7 +52,7 @@
     border-radius: 0.5em;
     -webkit-appearance: none;
     background-color: rgb(255, 255, 255);
-    background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23007CB2%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E"),
+    background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23007CB2%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E'),
       linear-gradient(to bottom, #ffffff 0%, #e5e5e5 100%);
     background-repeat: no-repeat, repeat;
     background-position: right 0.7em top 50%, 0px 0px;
@@ -61,7 +64,7 @@
   .picker:focus {
     outline: none;
   }
-  
+
   .priority-picker:hover {
     border-color: #888;
   }
@@ -74,74 +77,80 @@
   }
 
   .button-container {
-    padding: 1em;
-    position: fixed;
-    bottom: 3em;
-    left: 0;
-    width: 100%;
+    display: flex;
+    flex: auto;
+    flex-direction: row;
+    justify-content: space-between;
   }
 
-  .red-holder {
-    left: 0;
-    position: fixed;
-    margin-left: 1em;
+  .button-link {
+    border-radius: 6px;
+    display: inline-block;
+    cursor: pointer;
+    color: #ffffff;
+    font-family: Arial;
+    font-size: 15px;
+    font-weight: bold;
+    padding: 6px 24px;
+    margin: 3px;
+    text-decoration: none;
+    white-space: nowrap;
   }
-  
+
+  .button-link:active {
+    position: relative;
+    top: 1px;
+  }
+
+  .button-holder {
+    align-self: flex-end;
+  }
+
+  .button-disabled {
+    @extend .button-link;
+    cursor: default;
+    box-shadow: inset 0px 1px 0px 0px #9b9b9b;
+    background: linear-gradient(to bottom, #bdbdbd 5%, #aaaaaa 100%);
+    background-color: #bdbdbd;
+    border: 1px solid #707070;
+    text-shadow: 0px 1px 0px #777777;
+  }
+  .button-disabled:active {
+    top: 0px;
+  }
+
   .red-button {
-    box-shadow:inset 0px 1px 0px 0px #f7c5c0;
-    background:linear-gradient(to bottom, #fc8d83 5%, #e4685d 100%);
-    background-color:#fc8d83;
-    border-radius:6px;
-    border:1px solid #d83526;
-    display:inline-block;
-    cursor:pointer;
-    color:#ffffff;
-    font-family:Arial;
-    font-size:15px;
-    font-weight:bold;
-    padding:6px 24px;
-    text-decoration:none;
-    text-shadow:0px 1px 0px #b23e35;
+    @extend .button-link;
+    box-shadow: inset 0px 1px 0px 0px #f7c5c0;
+    background: linear-gradient(to bottom, #fc8d83 5%, #e4685d 100%);
+    background-color: #fc8d83;
+    border: 1px solid #d83526;
+    text-shadow: 0px 1px 0px #b23e35;
   }
   .red-button:hover {
-    background:linear-gradient(to bottom, #e4685d 5%, #fc8d83 100%);
-    background-color:#e4685d;
-  }
-  .red-button:active {
-    position:relative;
-    top:1px;
-  }
-  
-  .green-holder {
-    right: 0;
-    position: fixed;
-    margin-right: 1em;
+    background: linear-gradient(to bottom, #e4685d 5%, #fc8d83 100%);
+    background-color: #e4685d;
   }
 
   .green-button {
-    box-shadow:inset 0px 1px 0px 0px #a4e271;
-    background:linear-gradient(to bottom, #89c403 5%, #77a809 100%);
-    background-color:#89c403;
-    border-radius:6px;
-    border:1px solid #74b807;
-    display:inline-block;
-    cursor:pointer;
-    color:#ffffff;
-    font-family:Arial;
-    font-size:15px;
-    font-weight:bold;
-    padding:6px 24px;
-    text-decoration:none;
-    text-shadow:0px 1px 0px #528009;
+    @extend .button-link;
+    box-shadow: inset 0px 1px 0px 0px #a4e271;
+    background: linear-gradient(to bottom, #89c403 5%, #77a809 100%);
+    background-color: #89c403;
+    border: 1px solid #74b807;
+    text-shadow: 0px 1px 0px #528009;
   }
   .green-button:hover {
-    background:linear-gradient(to bottom, #77a809 5%, #89c403 100%);
-    background-color:#77a809;
+    background: linear-gradient(to bottom, #77a809 5%, #89c403 100%);
+    background-color: #77a809;
   }
-  .green-button:active {
-    position:relative;
-    top:1px;
-  }
-  
 
+  input:invalid {
+    border: 2px solid #ca0000;
+  }
+
+  input[type='number'] {
+    margin: 3px;
+    width: 50px;
+  }
 }


### PR DESCRIPTION
I addressed two nitpicks raised in PR [#71](https://github.com/dvx/lofi/pull/71). I also messed around with the behaviour and style of the Settings window (had a bug with overlapping buttons when you made the window smaller).

Here's what this PR contains:
- Added validation on volume_increment (value between 0 and 100 inclusively)
- Settings window commit only enabled on changes and or valid volume_increment value
- Fixed bad spacing on volume_increment input number
- Disable display volume (hard coded for now)
- Added safety checks on volume_increment (had NRE for some reason after I pulled the merged PR)