### PR TITLE
Api Throttling and Freemium Controls Hiding

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   </tr>
 </table>
 
-Lofi is a mini Spotify player with visualizations. It is *not* a replacement for the Spotify Desktop app, nor does it play music independently of the Spotify app; instead, Lofi works alongside it to provide a more intuitive and pleasant access to common features, including pausing/playing, and previous/next track. Lofi also displays cover art and track info stylishly and it facilitates WebGL-powered audio visualizations for both Windows and MacOS. In other words, it's a "tiny Spotify player" or a "mini mode" for the Spotify desktop app.
+Lofi is a mini Spotify player with visualizations. It is _not_ a replacement for the Spotify Desktop app, nor does it play music independently of the Spotify app; instead, Lofi works alongside it to provide a more intuitive and pleasant access to common features, including pausing/playing, and previous/next track. Lofi also displays cover art and track info stylishly and it facilitates WebGL-powered audio visualizations for both Windows and MacOS. In other words, it's a "tiny Spotify player" or a "mini mode" for the Spotify desktop app.
 
 It is possible to make Lofi work with other audio sources (including YouTube and SoundCloud), and that might make it on the roadmap at some point.
 
@@ -33,9 +33,9 @@ It is possible to make Lofi work with other audio sources (including YouTube and
 
 To build, you'll need `node-gyp`, a compatible Python version (2.x), and your operating system's SDK (Microsoft Build Tools or Xcode). Linux native compilation is currently not supported. First, you'll need to run:
 
-````
+```
 $ yarn install
-````
+```
 
 If you have more than one Python installation on your system, you can prevent the build from failing by editing the `package.json` file in the root directory.
 Edit the build argument from
@@ -71,16 +71,18 @@ Use `yarn run production` (instead of `development`) to start the front-end in n
 ## `node-sass` compatibility
 
 You might need to change the `node-sass` version inside `package.json` to be compliant with your `nodejs` version or the `node-gyp` build might fail.
-  
-NodeJS  | Minimum node-sass version | Node Module
---------|--------------------------|------------
-Node 12 | 4.12+                    | 72
-Node 11 | 4.10+                    | 67
-Node 10 | 4.9+                     | 64
-Node 8  | 4.5.3+                   | 57
+
+| NodeJS  | Minimum node-sass version | Node Module |
+| ------- | ------------------------- | ----------- |
+| Node 12 | 4.12+                     | 72          |
+| Node 11 | 4.10+                     | 67          |
+| Node 10 | 4.9+                      | 64          |
+| Node 8  | 4.5.3+                    | 57          |
 
 # Bugs, issues, and contributing
-See something you don't like? Have a feature request? Is your computer on fire? Feel free to open an issue or make a pull request. The more the merrier.
+
+See something you don't like? Have a feature request? Is your computer on fire? Feel free to open an issue, make a pull request or join our [Discord](https://discord.gg/YuH9UJk) server. The more the merrier.
 
 # License
+
 MIT.

--- a/src/api/spotify-api.ts
+++ b/src/api/spotify-api.ts
@@ -1,0 +1,45 @@
+const API_URL = 'https://api.spotify.com/v1';
+
+class SpotifyApi {
+  private isThrottled: boolean;
+  private throttleTime: number;
+
+  async fetch(input: RequestInfo, init?: RequestInit) {
+    if (this.isThrottled) {
+      const timeLeft = this.throttleTime - new Date().getTime();
+      if (timeLeft > 0) {
+        console.warn(
+          `Spotify API call ignored, waiting ${timeLeft}ms... (${input})`
+        );
+        return;
+      } else {
+        this.isThrottled = false;
+      }
+    }
+
+    const res = await fetch(API_URL + input, init);
+    switch (res.status) {
+      case 200: {
+        return await res.json();
+      }
+      case 204: {
+        return null;
+      }
+      case 429: {
+        const retryAfter = parseInt(res.headers.get('retry-after')) + 1;
+        if (retryAfter) {
+          this.throttleTime = new Date().getTime() + retryAfter * 1000;
+          this.isThrottled = true;
+        }
+        break;
+      }
+    }
+
+    const { error } = await res.json();
+    console.error(`${error.status}: ${error.message}`);
+
+    return null;
+  }
+}
+
+export const SpotifyApiInstance = new SpotifyApi();

--- a/src/api/spotify-api.ts
+++ b/src/api/spotify-api.ts
@@ -14,6 +14,11 @@ class SpotifyApi {
   }
 
   async fetch(input: RequestInfo, init?: RequestInit) {
+    if (!this.accessToken) {
+      console.warn(`Access token not set, ignoring fetch '${input}'`);
+      return;
+    }
+
     if (this.isThrottled) {
       const timeLeft = this.throttleTime - new Date().getTime();
       if (timeLeft > 0) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,8 +11,6 @@ export const WIDTH = 150;
 export const MIN_SIDE_LENGTH = 150;
 export const MAX_SIDE_LENGTH = 300;
 
-export const API_URL = 'https://api.spotify.com/v1';
-
 export const LOFI_SHUFFLED_PLAYLIST_NAME = 'Shuffled by Lofi';
 
 // Native shadows are buggy, so just make the main (transparent) window big enough so it can hold the shadow as well

--- a/src/main/auth.ts
+++ b/src/main/auth.ts
@@ -58,7 +58,7 @@ export async function startAuthServer() {
   console.log('Starting auth server...');
   if (!server) {
     server = http.createServer(async (request, response) => {
-      handleServerResponse(request, response);
+      await handleServerResponse(request, response);
     });
 
     server.listen(AUTH_PORT);
@@ -123,6 +123,9 @@ async function handleServerResponse(request: any, response: any) {
   try {
     if (queryData.state !== codeState) {
       console.error('Invalid state');
+      response.end(
+        'Lofi authorization error: invalid state, , you may close this window and retry.'
+      );
       return;
     }
 

--- a/src/renderer/components/Lofi/Cover/Controls/index.tsx
+++ b/src/renderer/components/Lofi/Cover/Controls/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import './style.scss';
-import { API_URL } from '../../../../../constants';
+import { SpotifyApiInstance } from '../../../../../api/spotify-api';
 
 class Controls extends React.Component<any, any> {
   constructor(props: any) {
@@ -9,14 +9,14 @@ class Controls extends React.Component<any, any> {
 
   async pausePlay() {
     if (this.props.parent.getPlayState()) {
-      fetch(API_URL + '/me/player/pause', {
+      SpotifyApiInstance.fetch('/me/player/pause', {
         method: 'PUT',
         headers: new Headers({
           Authorization: 'Bearer ' + this.props.token,
         }),
       });
     } else {
-      fetch(API_URL + '/me/player/play', {
+      SpotifyApiInstance.fetch('/me/player/play', {
         method: 'PUT',
         headers: new Headers({
           Authorization: 'Bearer ' + this.props.token,
@@ -28,7 +28,7 @@ class Controls extends React.Component<any, any> {
   }
 
   async forward() {
-    fetch(API_URL + '/me/player/next', {
+    SpotifyApiInstance.fetch('/me/player/next', {
       method: 'POST',
       headers: new Headers({
         Authorization: 'Bearer ' + this.props.token,
@@ -41,7 +41,7 @@ class Controls extends React.Component<any, any> {
   }
 
   async backward() {
-    fetch(API_URL + '/me/player/previous', {
+    SpotifyApiInstance.fetch('/me/player/previous', {
       method: 'POST',
       headers: new Headers({
         Authorization: 'Bearer ' + this.props.token,

--- a/src/renderer/components/Lofi/Cover/Controls/index.tsx
+++ b/src/renderer/components/Lofi/Cover/Controls/index.tsx
@@ -15,9 +15,6 @@ class Controls extends React.Component<any, any> {
   async getUserAccountType() {
     const userProfile = await SpotifyApiInstance.fetch('/me', {
       method: 'GET',
-      headers: new Headers({
-        Authorization: 'Bearer ' + this.props.token,
-      }),
     });
 
     this.accountType = userProfile.product;
@@ -27,16 +24,10 @@ class Controls extends React.Component<any, any> {
     if (this.props.parent.getPlayState()) {
       SpotifyApiInstance.fetch('/me/player/pause', {
         method: 'PUT',
-        headers: new Headers({
-          Authorization: 'Bearer ' + this.props.token,
-        }),
       });
     } else {
       SpotifyApiInstance.fetch('/me/player/play', {
         method: 'PUT',
-        headers: new Headers({
-          Authorization: 'Bearer ' + this.props.token,
-        }),
       });
     }
     // Assume original state is correct and make UI a bit snappier
@@ -46,9 +37,6 @@ class Controls extends React.Component<any, any> {
   async forward() {
     SpotifyApiInstance.fetch('/me/player/next', {
       method: 'POST',
-      headers: new Headers({
-        Authorization: 'Bearer ' + this.props.token,
-      }),
     }).then(() => {
       // Spotify API doesn't update fast enough sometimes, so give it some leeway
       setTimeout(this.props.parent.listeningTo.bind(this), 2000);
@@ -59,9 +47,6 @@ class Controls extends React.Component<any, any> {
   async backward() {
     SpotifyApiInstance.fetch('/me/player/previous', {
       method: 'POST',
-      headers: new Headers({
-        Authorization: 'Bearer ' + this.props.token,
-      }),
     }).then(() => {
       // Spotify API doesn't update fast enough sometimes, so give it some leeway
       setTimeout(this.props.parent.listeningTo.bind(this), 2000);

--- a/src/renderer/components/Lofi/Cover/index.tsx
+++ b/src/renderer/components/Lofi/Cover/index.tsx
@@ -186,7 +186,11 @@ class Cover extends React.Component<any, any> {
     // Fixes https://github.com/dvx/lofi/issues/31
     const currently_playing = this.state.currently_playing;
 
-    if (currently_playing.is_playing || !currently_playing.progress_ms) {
+    if (
+      !currently_playing ||
+      !currently_playing.progress_ms ||
+      currently_playing.is_playing
+    ) {
       return;
     }
 

--- a/src/renderer/components/Lofi/Cover/index.tsx
+++ b/src/renderer/components/Lofi/Cover/index.tsx
@@ -133,9 +133,6 @@ class Cover extends React.Component<any, any> {
       '/me/player/volume?volume_percent=' + Math.round(percent),
       {
         method: 'PUT',
-        headers: new Headers({
-          Authorization: 'Bearer ' + this.props.token,
-        }),
       }
     );
   }
@@ -197,9 +194,6 @@ class Cover extends React.Component<any, any> {
       '/me/player/seek?position_ms=' + currentlyPlaying.progress_ms,
       {
         method: 'PUT',
-        headers: new Headers({
-          Authorization: 'Bearer ' + this.props.token,
-        }),
       }
     );
   }
@@ -209,9 +203,6 @@ class Cover extends React.Component<any, any> {
       '/me/player?type=episode,track',
       {
         method: 'GET',
-        headers: new Headers({
-          Authorization: 'Bearer ' + this.props.token,
-        }),
       }
     );
 
@@ -266,9 +257,6 @@ class Cover extends React.Component<any, any> {
       '/playlists/' + playlist_id + '/tracks',
       {
         method: 'GET',
-        headers: new Headers({
-          Authorization: 'Bearer ' + this.props.token,
-        }),
       }
     );
 
@@ -287,9 +275,6 @@ class Cover extends React.Component<any, any> {
     while (playlist.next) {
       playlist = await SpotifyApiInstance.fetch(playlist.next, {
         method: 'GET',
-        headers: new Headers({
-          Authorization: 'Bearer ' + this.props.token,
-        }),
       });
 
       if (!playlist) {
@@ -329,9 +314,6 @@ class Cover extends React.Component<any, any> {
       '/playlists/' + playlist_id + '/tracks',
       {
         method: 'GET',
-        headers: new Headers({
-          Authorization: 'Bearer ' + this.props.token,
-        }),
       }
     );
 
@@ -381,9 +363,6 @@ class Cover extends React.Component<any, any> {
       '/me/playlists?limit=' + limit,
       {
         method: 'GET',
-        headers: new Headers({
-          Authorization: 'Bearer ' + this.props.token,
-        }),
       }
     );
 

--- a/src/renderer/components/Lofi/Cover/index.tsx
+++ b/src/renderer/components/Lofi/Cover/index.tsx
@@ -372,11 +372,7 @@ class Cover extends React.Component<any, any> {
 
     playlists = playlists.concat(playlistObject.items);
     while (playlistObject.next) {
-      playlistObject = await SpotifyApiInstance.fetch(playlistObject.next, {
-        headers: new Headers({
-          Authorization: 'Bearer ' + this.props.token,
-        }),
-      });
+      playlistObject = await SpotifyApiInstance.fetch(playlistObject.next);
 
       if (playlistObject) {
         playlists = playlists.concat(playlistObject.items);
@@ -561,7 +557,7 @@ class Cover extends React.Component<any, any> {
           />
         </RecreateChildOnPropsChange>
         {this.state.currently_playing ? (
-          <Controls parent={this} token={this.props.token} />
+          <Controls parent={this} />
         ) : (
           <Waiting />
         )}

--- a/src/renderer/components/Lofi/index.tsx
+++ b/src/renderer/components/Lofi/index.tsx
@@ -98,7 +98,8 @@ class Lofi extends React.Component<any, any> {
       settings.setSync('refresh_token', data.refresh_token);
     }
 
-    SpotifyApiInstance.refreshToken = data?.refresh_token;
+    SpotifyApiInstance.updateTokens(data);
+
     this.setState({ access_token: data?.access_token });
     this.setState({ refresh_token: data?.refresh_token });
   }

--- a/src/renderer/components/Lofi/index.tsx
+++ b/src/renderer/components/Lofi/index.tsx
@@ -299,7 +299,6 @@ class Lofi extends React.Component<any, any> {
             settings={this.state.lofiSettings.window}
             side={this.state.window_side}
             lofi={this}
-            token={this.state.access_token}
           />
         ) : (
           <Welcome lofi={this} />


### PR DESCRIPTION
1. Centralized all Spotify API calls into a singleton
    * Easier error handling (e.g. status `429` api-throttling)
    * Will eventually allow testability/mocking of the api (unit test, still working on that, not sure it's worth the cost)
2. Retrieve the user account type and disable the controls if the user is not using a premium subscription (i.e. he's using free/open)
    * Requires new auth scope [user-read-private](https://developer.spotify.com/documentation/general/guides/scopes/#user-read-private)
    * Addresses issue #78