### PR TITLE
Version from npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ package
 
 # git merge files
 *.orig
+
+# generated version file
+version.generated.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 build
+dist
 node_modules
 pack
 src/renderer/static/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "install": "yarn run build",
     "config-xcode": "node-gyp configure -- -f xcode",
-    "build": "node-gyp rebuild --target=4.0.1 --arch=x64 --dist-url=https://atom.io/download/electron",
+    "build": "node-gyp rebuild --target=4.0.1 --arch=x64 --dist-url=https://atom.io/download/electron && genversion --es6 --semi version.generated.ts",
     "start": "electron ./pack/main.bundle.js",
     "dev": "yarn run development",
     "development": "rimraf pack && webpack --watch --config ./webpack.dev.js --progress --color",
@@ -48,6 +48,7 @@
     "electron": "^11.2.1",
     "electron-builder": "^22.9.1",
     "file-loader": "^6.2.0",
+    "genversion": "^3.0.1",
     "html-webpack-plugin": "^4.5.1",
     "native-ext-loader": "^2.3.0",
     "node-addon-api": "^3.1.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 import * as os from 'os';
+import { version } from '../version.generated';
 
 export const SPOTIFY_API_URL = 'https://api.spotify.com/v1';
 
@@ -31,7 +32,7 @@ export const SETTINGS_CONTAINER = {
 };
 
 export const DEFAULT_SETTINGS = {
-  version: '1.6.0',
+  version: version,
   debug: false,
   hardware_acceleration: true,
   lofi: {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -8,6 +8,7 @@ import { MACOS, WINDOWS, LINUX, CONTAINER, SETTINGS_CONTAINER, DEFAULT_SETTINGS 
 import '../../build/Release/black-magic.node';
 import '../../icon.png';
 import '../../icon.ico';
+import { version } from '../../version.generated';
 
 // Visualizations look snappier on 60Hz refresh rate screens if we disable vsync
 app.commandLine.appendSwitch('disable-gpu-vsync');
@@ -235,7 +236,7 @@ let tray = null;
 app.on('ready', () => {
   settings.defaults(DEFAULT_SETTINGS);
   // If we have a settings version mismatch, nuke the settings
-  if (!settings.hasSync('version') || String(settings.getSync('version')) !== String(DEFAULT_SETTINGS.version)) {
+  if (!settings.hasSync('version') || String(settings.getSync('version')) !== version) {
     settings.resetToDefaultsSync();
 
     // Default position is based on OS; (0,0) sometimes breaks
@@ -261,7 +262,7 @@ app.on('ready', () => {
   tray = new Tray(nativeImage.createFromPath(__dirname + '/icon.png').resize({ height: 16 }));
   const contextMenu = Menu.buildFromTemplate([
     {
-      label: `lofi v${DEFAULT_SETTINGS.version}`,
+      label: `lofi v${version}`,
       enabled: false,
       icon: nativeImage.createFromPath(__dirname + '/icon.png').resize({ height: 16 }),
     },
@@ -289,7 +290,7 @@ app.on('ready', () => {
     },
   ]);
   tray.setContextMenu(contextMenu);
-  tray.setToolTip(`lofi v${DEFAULT_SETTINGS.version}`);
+  tray.setToolTip(`lofi v${version}`);
 });
 
 // Quit when all windows are closed.

--- a/src/renderer/components/Lofi/About/index.tsx
+++ b/src/renderer/components/Lofi/About/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import TitleBar from 'frameless-titlebar';
-import * as j from '../../../../../package.json';
 import './style.scss';
 import { Platform } from 'frameless-titlebar/dist/title-bar/typings';
+import { version } from '../../../../../version.generated';
 
 class About extends React.Component<any, any> {
   render() {
@@ -23,13 +23,13 @@ class About extends React.Component<any, any> {
         />
         <div className="about-wrapper">
           <div style={{ textAlign: 'center' }}>
-            <h1>Lofi v{j.version}</h1>
+            <h1>Lofi v{version}</h1>
             <div>🎵🔉 A mini Spotify player with WebGL visualizations.</div>
           </div>
           <br />
           <br />
           <code>
-            Copyright (c) 2019-2020 David Titarenco
+            Copyright (c) 2019-{new Date().getFullYear()} David Titarenco
             <br />
             <br />
             Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/yarn.lock
+++ b/yarn.lock
@@ -1122,7 +1122,7 @@ commander@^5.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
-commander@^7.0.0:
+commander@^7.0.0, commander@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
@@ -1875,6 +1875,13 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+find-package@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/find-package/-/find-package-1.0.0.tgz#d7738da67e3c5f055c24d3e19aa1aeed063c3e83"
+  integrity sha1-13ONpn48XwVcJNPhmqGu7QY8PoM=
+  dependencies:
+    parents "^1.0.1"
+
 find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -1988,6 +1995,14 @@ gaze@^1.0.0:
   integrity sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==
   dependencies:
     globule "^1.0.0"
+
+genversion@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/genversion/-/genversion-3.0.1.tgz#d6f75e4da9a824635610892a776ab3b588324677"
+  integrity sha512-tgZ3vLeXcb0RdJm2sJNNfBaahWmI3lumJ1z/IztWUUb6LOhEE6h4eRehheWoa/ITEWhrn4E5EaEPGSl5MyM3Zw==
+  dependencies:
+    commander "^7.2.0"
+    find-package "^1.0.0"
 
 get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
@@ -3265,6 +3280,13 @@ param-case@^3.0.3:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
+parents@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parents/-/parents-1.0.1.tgz#fedd4d2bf193a77745fe71e371d73c3307d9c751"
+  integrity sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=
+  dependencies:
+    path-platform "~0.11.15"
+
 parse-json@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
@@ -3307,6 +3329,11 @@ path-parse@^1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-platform@~0.11.15:
+  version "0.11.15"
+  resolved "https://registry.yarnpkg.com/path-platform/-/path-platform-0.11.15.tgz#e864217f74c36850f0852b78dc7bf7d4a5721bf2"
+  integrity sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=
 
 path-type@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
- Stop using `package.json` to retrieve the app version (sys tray tooltip, about window and settings check)
- Ignore the `dist` folder when running prettier
- Use the current year in the copyright