### PR TITLE
feat: add rounded corners

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,9 @@ export const MAX_BAR_THICKNESS = 20;
 export const MIN_FONT_SIZE = 6;
 export const MAX_FONT_SIZE = 32;
 export const TRACK_INFO_GAP = { X: 10, Y: 10 };
+export const MAX_CORNER_RADIUS = 20;
+export const WIN_11_CORNER_RADIUS = 8;
+export const MACOS_CORNER_RADIUS = 9;
 
 export const MIN_SKIP_SONG_DELAY = 5;
 export const MAX_SKIP_SONG_DELAY = 60;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,8 +13,6 @@ export const MIN_FONT_SIZE = 6;
 export const MAX_FONT_SIZE = 32;
 export const TRACK_INFO_GAP = { X: 10, Y: 10 };
 export const MAX_CORNER_RADIUS = 20;
-export const WIN_11_CORNER_RADIUS = 8;
-export const MACOS_CORNER_RADIUS = 9;
 
 export const MIN_SKIP_SONG_DELAY = 5;
 export const MAX_SKIP_SONG_DELAY = 60;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -107,7 +107,7 @@ const MAIN_WINDOW_OPTIONS: BrowserWindowConstructorOptions = {
     nodeIntegration: true,
     contextIsolation: false,
   },
-  backgroundColor: '#000000',
+  backgroundColor: 'rgba(0,0,0,0)',
   roundedCorners: false,
 };
 

--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -34,6 +34,7 @@ export interface Settings {
   trackInfoBackgroundColor: string;
   trackInfoBackgroundOpacity: number;
   showFreemiumWarning: boolean;
+  cornerRadius: number;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -64,4 +65,5 @@ export const DEFAULT_SETTINGS: Settings = {
   trackInfoBackgroundColor: '#000000',
   trackInfoBackgroundOpacity: 50,
   showFreemiumWarning: true,
+  cornerRadius: 0,
 };

--- a/src/renderer/app/index.tsx
+++ b/src/renderer/app/index.tsx
@@ -278,7 +278,7 @@ export const App: FunctionComponent = () => {
     <VisibleUi
       id="visible-ui"
       className="click-on"
-      style={cornerRadius ? { borderRadius: cornerRadius, overflow: 'hidden' } : {}}>
+      style={cornerRadius ? { borderRadius: `${cornerRadius}%`, overflow: 'hidden' } : {}}>
       {shouldShowSettings && (
         <WindowPortal onUnload={() => setShouldShowSettings(false)} name={WindowName.Settings}>
           <SettingsWindow

--- a/src/renderer/app/index.tsx
+++ b/src/renderer/app/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { Display, ipcRenderer } from 'electron';
-import React, { FunctionComponent, useCallback, useEffect, useState } from 'react';
+import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import { IpcMessage, WindowName } from '../../constants';
@@ -79,6 +79,7 @@ export const App: FunctionComponent = () => {
   const { state, dispatch } = useSettings();
   const { state: currentlyPlaying, dispatch: currentlyPlayingDispatch } = useCurrentlyPlaying();
   const { accessToken, refreshToken, visualizationId, visualizationType } = state || DEFAULT_SETTINGS;
+  const { cornerRadius } = useMemo(() => state, [state]);
 
   const updateTokens = useCallback(
     async (data: AuthData) => {
@@ -274,7 +275,10 @@ export const App: FunctionComponent = () => {
   );
 
   return (
-    <VisibleUi id="visible-ui" className="click-on">
+    <VisibleUi
+      id="visible-ui"
+      className="click-on"
+      style={cornerRadius ? { borderRadius: cornerRadius, overflow: 'hidden' } : {}}>
       {shouldShowSettings && (
         <WindowPortal onUnload={() => setShouldShowSettings(false)} name={WindowName.Settings}>
           <SettingsWindow

--- a/src/renderer/windows/settings/window-settings.tsx
+++ b/src/renderer/windows/settings/window-settings.tsx
@@ -1,7 +1,8 @@
+import os from 'node:os';
 import React, { FunctionComponent } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { MAX_BAR_THICKNESS } from '../../../constants';
+import { MACOS_CORNER_RADIUS, MAX_BAR_THICKNESS, MAX_CORNER_RADIUS, WIN_11_CORNER_RADIUS } from '../../../constants';
 import { DEFAULT_SETTINGS, Settings } from '../../../models/settings';
 import {
   ColorInput,
@@ -16,10 +17,22 @@ import {
 } from '../../components';
 import { INPUT_COLOR } from '../../components/mantine.styled';
 
+function calcDefaultRadius(): number {
+  const osRelease = os.release();
+  if (osRelease.startsWith('11')) {
+    return WIN_11_CORNER_RADIUS;
+  }
+  if (osRelease.startsWith('Darwin')) {
+    return MACOS_CORNER_RADIUS;
+  }
+  return DEFAULT_SETTINGS.cornerRadius;
+}
+
 export const WindowSettings: FunctionComponent = () => {
   const { register, watch } = useFormContext<Settings>();
 
   const barThicknessWatch = watch('barThickness');
+  const cornerRadiusWatch = watch('cornerRadius');
 
   return (
     <FormGroup>
@@ -70,6 +83,20 @@ export const WindowSettings: FunctionComponent = () => {
           <Label>
             Progress bar color
             <ColorInput {...register('barColor')} />
+          </Label>
+        </Row>
+        <Row>
+          <Label>
+            Border Radius
+            <Slider
+              type="range"
+              min={0}
+              max={MAX_CORNER_RADIUS}
+              step={1}
+              defaultValue={calcDefaultRadius()}
+              {...register('cornerRadius', { required: true, valueAsNumber: true })}
+            />
+            <RangeValue>{cornerRadiusWatch}</RangeValue>
           </Label>
         </Row>
       </FieldSet>

--- a/src/renderer/windows/settings/window-settings.tsx
+++ b/src/renderer/windows/settings/window-settings.tsx
@@ -1,8 +1,7 @@
-import os from 'node:os';
 import React, { FunctionComponent } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { MACOS_CORNER_RADIUS, MAX_BAR_THICKNESS, MAX_CORNER_RADIUS, WIN_11_CORNER_RADIUS } from '../../../constants';
+import { MAX_BAR_THICKNESS, MAX_CORNER_RADIUS } from '../../../constants';
 import { DEFAULT_SETTINGS, Settings } from '../../../models/settings';
 import {
   ColorInput,
@@ -16,17 +15,6 @@ import {
   StyledCheckbox,
 } from '../../components';
 import { INPUT_COLOR } from '../../components/mantine.styled';
-
-function calcDefaultRadius(): number {
-  const osRelease = os.release();
-  if (osRelease.startsWith('11')) {
-    return WIN_11_CORNER_RADIUS;
-  }
-  if (osRelease.startsWith('Darwin')) {
-    return MACOS_CORNER_RADIUS;
-  }
-  return DEFAULT_SETTINGS.cornerRadius;
-}
 
 export const WindowSettings: FunctionComponent = () => {
   const { register, watch } = useFormContext<Settings>();
@@ -93,7 +81,7 @@ export const WindowSettings: FunctionComponent = () => {
               min={0}
               max={MAX_CORNER_RADIUS}
               step={1}
-              defaultValue={calcDefaultRadius()}
+              defaultValue={DEFAULT_SETTINGS.cornerRadius}
               {...register('cornerRadius', { required: true, valueAsNumber: true })}
             />
             <RangeValue>{cornerRadiusWatch}</RangeValue>


### PR DESCRIPTION
Added corner radius as a setting as well as default rounding for Windows 11 and MacOS

I only have a Windows 10 machine available to me for development, so testing on those OSes should be done to confirm default rounding is functioning as intended

Implements planned feature https://github.com/dvx/lofi/projects/5#card-90705511