### PR TITLE
Added option to temporarily show track info on track change

### DIFF
--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -23,6 +23,7 @@ export interface Settings {
   isOnLeft: boolean;
   isAlwaysShowTrackInfo: boolean;
   isAlwaysShowSongProgress: boolean;
+  showTrackInfoTemporarilyInSeconds: number;
   barThickness: number;
   barColor: string;
   size: number;
@@ -55,6 +56,7 @@ export const DEFAULT_SETTINGS: Settings = {
   isAlwaysOnTop: true,
   isVisibleInTaskbar: true,
   isAlwaysShowTrackInfo: false,
+  showTrackInfoTemporarilyInSeconds: 0,
   isAlwaysShowSongProgress: false,
   barThickness: 2,
   barColor: '#74C999',

--- a/src/renderer/app/cover/index.tsx
+++ b/src/renderer/app/cover/index.tsx
@@ -116,26 +116,32 @@ export const Cover: FunctionComponent<Props> = ({ settings, message, onVisualiza
           console.log(`New song '${songTitle}' by '${artist}.`);
           await refreshTrackLiked();
         }
-        showTrackInfoTemporarily();
+
+        if (!isAlwaysShowTrackInfo && showTrackInfoTemporarilyInSeconds) {
+          setShouldShowTrackInfo(true);
+
+          const timer = setTimeout(() => {
+            if (!document.getElementById('visible-ui')?.matches(':hover')) {
+              setShouldShowTrackInfo(false);
+            }
+            setTrackInfoTimer(null);
+          }, showTrackInfoTemporarilyInSeconds * ONE_SECOND_IN_MS);
+
+          setTrackInfoTimer(timer);
+        }
       }
     })();
-  }, [artist, currentSongId, refreshTrackLiked, songTitle, state.id, state.isPlaying]);
+  }, [
+    artist,
+    currentSongId,
+    refreshTrackLiked,
+    songTitle,
+    state.id,
+    state.isPlaying,
+    isAlwaysShowTrackInfo,
+    showTrackInfoTemporarilyInSeconds,
+  ]);
 
-  const showTrackInfoTemporarily = () => {
-    if (!isAlwaysShowTrackInfo && showTrackInfoTemporarilyInSeconds) {
-      setShouldShowTrackInfo(true);
-
-      const timer = setTimeout(() => {
-        if (!document.getElementById('visible-ui')?.matches(':hover')) {
-          setShouldShowTrackInfo(false);
-        }
-        setTrackInfoTimer(null);
-      }, showTrackInfoTemporarilyInSeconds * ONE_SECOND_IN_MS);
-    
-      setTrackInfoTimer(timer);
-    }
-  };
-  
   useEffect(() => {
     return () => {
       if (trackInfoTimer) {
@@ -217,7 +223,10 @@ export const Cover: FunctionComponent<Props> = ({ settings, message, onVisualiza
   }, [handlePlaybackChanged, trackInfoRefreshTimeInSeconds]);
 
   useEffect(() => {
-    const refreshTrackLikedIntervalId = setInterval(refreshTrackLiked, 2 * trackInfoRefreshTimeInSeconds * ONE_SECOND_IN_MS);
+    const refreshTrackLikedIntervalId = setInterval(
+      refreshTrackLiked,
+      2 * trackInfoRefreshTimeInSeconds * ONE_SECOND_IN_MS
+    );
     return () => {
       if (refreshTrackLikedIntervalId) {
         clearInterval(refreshTrackLikedIntervalId);
@@ -249,7 +258,7 @@ export const Cover: FunctionComponent<Props> = ({ settings, message, onVisualiza
       {state.id ? (
         <>
           {shouldShowTrackInfo && (
-            <WindowPortal name={WindowName.TrackInfo}>
+            <WindowPortal name={WindowName.TrackInfo} features={{ focusable: false }}>
               <TrackInfo track={songTitle} artist={artist} isOnLeft={isOnLeft} message={errorToDisplay || message} />
             </WindowPortal>
           )}

--- a/src/renderer/components/window-portal.tsx
+++ b/src/renderer/components/window-portal.tsx
@@ -63,7 +63,7 @@ interface Props {
   url?: string;
   name: string;
   title?: string;
-  features?: { width?: number; height?: number; isFullscreen?: boolean };
+  features?: { width?: number; height?: number; isFullscreen?: boolean; focusable?: boolean };
   children: ReactNode;
   onOpen?: (window: Window) => void;
   onUnload?: () => void;

--- a/src/renderer/windows/settings/window-settings.tsx
+++ b/src/renderer/windows/settings/window-settings.tsx
@@ -21,6 +21,7 @@ export const WindowSettings: FunctionComponent = () => {
 
   const barThicknessWatch = watch('barThickness');
   const cornerRadiusWatch = watch('cornerRadius');
+  const tempTrackInfoWatch = watch('showTrackInfoTemporarilyInSeconds');
 
   return (
     <FormGroup>
@@ -44,6 +45,20 @@ export const WindowSettings: FunctionComponent = () => {
             size="xs"
             {...register('isAlwaysShowTrackInfo')}
           />
+        </Row>
+        <Row>
+          <Label>
+            Show Track Info Temporarily (Seconds)
+            <Slider
+              type="range"
+              min={0}
+              max={10}
+              step={1}
+              defaultValue={DEFAULT_SETTINGS.showTrackInfoTemporarilyInSeconds}
+              {...register('showTrackInfoTemporarilyInSeconds', { required: true, valueAsNumber: true })}
+            />
+            <RangeValue>{tempTrackInfoWatch}</RangeValue>
+          </Label>
         </Row>
         <Row>
           <StyledCheckbox


### PR DESCRIPTION
Finally got around to adding this feature i suggested in #123 

It also shows when playback resumes as suggested by stamoun. I also managed to fix the issue of the window pulling focus when the track info appears.

I tested on windows 11 but don't have a mac to test on 