### PR TITLE
Temporary track info and Volume Control fixes

### DIFF
--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -23,6 +23,7 @@ export interface Settings {
   isOnLeft: boolean;
   isAlwaysShowTrackInfo: boolean;
   isAlwaysShowSongProgress: boolean;
+  showTrackInfoTemporarilyInSeconds: number;
   barThickness: number;
   barColor: string;
   size: number;
@@ -55,6 +56,7 @@ export const DEFAULT_SETTINGS: Settings = {
   isAlwaysOnTop: true,
   isVisibleInTaskbar: true,
   isAlwaysShowTrackInfo: false,
+  showTrackInfoTemporarilyInSeconds: 0,
   isAlwaysShowSongProgress: false,
   barThickness: 2,
   barColor: '#74C999',

--- a/src/renderer/app/cover/index.tsx
+++ b/src/renderer/app/cover/index.tsx
@@ -165,6 +165,11 @@ export const Cover: FunctionComponent<Props> = ({ settings, message, onVisualiza
     }
   }, [state.isPlaying, state.progress, state.userProfile?.accountType]);
 
+  const [localVolume, setLocalVolume] = useState(state.volume);
+  useEffect(() => {
+    setLocalVolume(state.volume);
+  }, [state.volume]);
+
   const changeVolume = useCallback(
     (newVolume: number) => {
       try {
@@ -190,18 +195,17 @@ export const Cover: FunctionComponent<Props> = ({ settings, message, onVisualiza
 
   const onMouseWheel = useCallback(
     async ({ deltaY }: WheelEvent): Promise<void> => {
-      const direction = Math.sign(deltaY);
-      const newVolume = clamp(state.volume - direction * volumeIncrement, 0, 100);
+      const direction = Math.sign(-deltaY);
+      console.log(`Mouse wheel direction: ${direction}`);
+      const newVolume = clamp(localVolume + volumeIncrement * direction, 0, 100);
+      setLocalVolume(newVolume);
       try {
-        // TODO use a state variable to buffer the volume change
-        if (newVolume !== state.volume) {
-          changeVolume(newVolume);
-        }
+        changeVolume(newVolume);
       } catch (error) {
         throw new Error(`Update volume error: ${error}`);
       }
     },
-    [changeVolume, state.volume, volumeIncrement]
+    [localVolume, volumeIncrement, changeVolume]
   );
 
   useEffect(() => {

--- a/src/renderer/app/cover/index.tsx
+++ b/src/renderer/app/cover/index.tsx
@@ -115,10 +115,9 @@ export const Cover: FunctionComponent<Props> = ({ settings, message, onVisualiza
           setCurrentSongId(state.id);
           console.log(`New song '${songTitle}' by '${artist}.`);
           await refreshTrackLiked();
-        }
-
-        if (!isAlwaysShowTrackInfo && showTrackInfoTemporarilyInSeconds) {
+        } else if (!isAlwaysShowTrackInfo && showTrackInfoTemporarilyInSeconds) {
           setShouldShowTrackInfo(true);
+          console.log('Showing track info temporarily.');
 
           const timer = setTimeout(() => {
             if (!document.getElementById('visible-ui')?.matches(':hover')) {
@@ -143,12 +142,12 @@ export const Cover: FunctionComponent<Props> = ({ settings, message, onVisualiza
   ]);
 
   useEffect(() => {
-    return () => {
-      if (trackInfoTimer) {
-        clearTimeout(trackInfoTimer);
-      }
-    };
-  }, [trackInfoTimer]);
+    if (!state.isPlaying && trackInfoTimer) {
+      clearTimeout(trackInfoTimer);
+      setTrackInfoTimer(null);
+      setShouldShowTrackInfo(false);
+    }
+  }, [state.isPlaying, trackInfoTimer]);
 
   const keepAlive = useCallback(async (): Promise<void> => {
     if (state.isPlaying || state.userProfile?.accountType !== AccountType.Premium) {

--- a/src/renderer/app/cover/index.tsx
+++ b/src/renderer/app/cover/index.tsx
@@ -208,12 +208,27 @@ export const Cover: FunctionComponent<Props> = ({ settings, message, onVisualiza
     [localVolume, volumeIncrement, changeVolume]
   );
 
+  const ondblClick = useCallback((): void => {
+    console.log('Double clicked');
+    // Add functionality here
+    // Tried opening spotify app but couldn't get it to work
+  }, []);
+
   useEffect(() => {
-    document.getElementById('visible-ui').addEventListener('mousewheel', onMouseWheel);
+    const el = document.getElementById('visible-ui');
+    el.addEventListener('mousewheel', onMouseWheel);
     return () => {
-      document.getElementById('visible-ui').removeEventListener('mousewheel', onMouseWheel);
+      el.removeEventListener('mousewheel', onMouseWheel);
     };
   }, [onMouseWheel]);
+
+  useEffect(() => {
+    const el = document.getElementById('visible-ui');
+    el.addEventListener('dblclick', ondblClick);
+    return () => {
+      el.removeEventListener('dblclick', ondblClick);
+    };
+  }, [ondblClick]);
 
   useEffect(() => {
     const listeningToIntervalId = setInterval(handlePlaybackChanged, trackInfoRefreshTimeInSeconds * ONE_SECOND_IN_MS);

--- a/src/renderer/app/cover/index.tsx
+++ b/src/renderer/app/cover/index.tsx
@@ -116,26 +116,32 @@ export const Cover: FunctionComponent<Props> = ({ settings, message, onVisualiza
           console.log(`New song '${songTitle}' by '${artist}.`);
           await refreshTrackLiked();
         }
-        showTrackInfoTemporarily();
+
+        if (!isAlwaysShowTrackInfo && showTrackInfoTemporarilyInSeconds) {
+          setShouldShowTrackInfo(true);
+
+          const timer = setTimeout(() => {
+            if (!document.getElementById('visible-ui')?.matches(':hover')) {
+              setShouldShowTrackInfo(false);
+            }
+            setTrackInfoTimer(null);
+          }, showTrackInfoTemporarilyInSeconds * ONE_SECOND_IN_MS);
+
+          setTrackInfoTimer(timer);
+        }
       }
     })();
-  }, [artist, currentSongId, refreshTrackLiked, songTitle, state.id, state.isPlaying]);
+  }, [
+    artist,
+    currentSongId,
+    refreshTrackLiked,
+    songTitle,
+    state.id,
+    state.isPlaying,
+    isAlwaysShowTrackInfo,
+    showTrackInfoTemporarilyInSeconds,
+  ]);
 
-  const showTrackInfoTemporarily = () => {
-    if (!isAlwaysShowTrackInfo && showTrackInfoTemporarilyInSeconds) {
-      setShouldShowTrackInfo(true);
-
-      const timer = setTimeout(() => {
-        if (!document.getElementById('visible-ui')?.matches(':hover')) {
-          setShouldShowTrackInfo(false);
-        }
-        setTrackInfoTimer(null);
-      }, showTrackInfoTemporarilyInSeconds * ONE_SECOND_IN_MS);
-    
-      setTrackInfoTimer(timer);
-    }
-  };
-  
   useEffect(() => {
     return () => {
       if (trackInfoTimer) {
@@ -217,7 +223,10 @@ export const Cover: FunctionComponent<Props> = ({ settings, message, onVisualiza
   }, [handlePlaybackChanged, trackInfoRefreshTimeInSeconds]);
 
   useEffect(() => {
-    const refreshTrackLikedIntervalId = setInterval(refreshTrackLiked, 2 * trackInfoRefreshTimeInSeconds * ONE_SECOND_IN_MS);
+    const refreshTrackLikedIntervalId = setInterval(
+      refreshTrackLiked,
+      2 * trackInfoRefreshTimeInSeconds * ONE_SECOND_IN_MS
+    );
     return () => {
       if (refreshTrackLikedIntervalId) {
         clearInterval(refreshTrackLikedIntervalId);
@@ -249,7 +258,7 @@ export const Cover: FunctionComponent<Props> = ({ settings, message, onVisualiza
       {state.id ? (
         <>
           {shouldShowTrackInfo && (
-            <WindowPortal name={WindowName.TrackInfo}>
+            <WindowPortal name={WindowName.TrackInfo} features={{ focusable: false }}>
               <TrackInfo track={songTitle} artist={artist} isOnLeft={isOnLeft} message={errorToDisplay || message} />
             </WindowPortal>
           )}

--- a/src/renderer/components/window-portal.tsx
+++ b/src/renderer/components/window-portal.tsx
@@ -63,7 +63,7 @@ interface Props {
   url?: string;
   name: string;
   title?: string;
-  features?: { width?: number; height?: number; isFullscreen?: boolean };
+  features?: { width?: number; height?: number; isFullscreen?: boolean; focusable?: boolean };
   children: ReactNode;
   onOpen?: (window: Window) => void;
   onUnload?: () => void;

--- a/src/renderer/windows/settings/window-settings.tsx
+++ b/src/renderer/windows/settings/window-settings.tsx
@@ -52,7 +52,7 @@ export const WindowSettings: FunctionComponent = () => {
             <Slider
               type="range"
               min={0}
-              max={10}
+              max={15}
               step={1}
               defaultValue={DEFAULT_SETTINGS.showTrackInfoTemporarilyInSeconds}
               {...register('showTrackInfoTemporarilyInSeconds', { required: true, valueAsNumber: true })}

--- a/src/renderer/windows/settings/window-settings.tsx
+++ b/src/renderer/windows/settings/window-settings.tsx
@@ -21,6 +21,7 @@ export const WindowSettings: FunctionComponent = () => {
 
   const barThicknessWatch = watch('barThickness');
   const cornerRadiusWatch = watch('cornerRadius');
+  const tempTrackInfoWatch = watch('showTrackInfoTemporarilyInSeconds');
 
   return (
     <FormGroup>
@@ -44,6 +45,20 @@ export const WindowSettings: FunctionComponent = () => {
             size="xs"
             {...register('isAlwaysShowTrackInfo')}
           />
+        </Row>
+        <Row>
+          <Label>
+            Show Track Info Temporarily (Seconds)
+            <Slider
+              type="range"
+              min={0}
+              max={10}
+              step={1}
+              defaultValue={DEFAULT_SETTINGS.showTrackInfoTemporarilyInSeconds}
+              {...register('showTrackInfoTemporarilyInSeconds', { required: true, valueAsNumber: true })}
+            />
+            <RangeValue>{tempTrackInfoWatch}</RangeValue>
+          </Label>
         </Row>
         <Row>
           <StyledCheckbox


### PR DESCRIPTION
Adjusted some settings of the temporary track info and hide it when music is paused.

Added a local volume variable to store volume changes if api is throttling or delayed.

Also tried to see if i could focus the spotify app on double click of the lofi window. Couldnt get it to work but left the double click event for a future feature.