### PR TITLE
Spotify OAuth2.0 Compliance Patch

### DIFF
--- a/src/main/auth.ts
+++ b/src/main/auth.ts
@@ -17,7 +17,7 @@ let onTokenRetrieved: (data: AuthData) => void = null;
 
 const AUTH_URL = 'https://accounts.spotify.com/authorize';
 const AUTH_TOKEN_URL = 'https://accounts.spotify.com/api/token';
-const AUTH_CLIENT_ID = '69eca11b9ccd4bd3a7e01e6f9ddb5205';
+const AUTH_CLIENT_ID = '8a501eb93a49490589ee2ca4a25615f5';
 const AUTH_PORT = 41419;
 const AUTH_SCOPES = [
   'user-read-playback-state',

--- a/src/main/auth.ts
+++ b/src/main/auth.ts
@@ -49,7 +49,7 @@ export const getAuthUrl = (): string => {
   const scopes = AUTH_SCOPES.join('%20');
 
   const authUrl =
-    `${AUTH_URL}?response_type=code&client_id=${AUTH_CLIENT_ID}&redirect_uri=http://localhost:${AUTH_PORT}&` +
+    `${AUTH_URL}?response_type=code&client_id=${AUTH_CLIENT_ID}&redirect_uri=http://127.0.0.1:${AUTH_PORT}&` +
     `scope=${scopes}&state=${codeState}&code_challenge=${codeChallenge}&code_challenge_method=S256`;
 
   return authUrl;
@@ -120,7 +120,7 @@ const retrieveAccessToken = async (verifier: string, code: string): Promise<Auth
 
   const body =
     `client_id=${AUTH_CLIENT_ID}&grant_type=authorization_code&` +
-    `code=${code}&redirect_uri=http://localhost:${AUTH_PORT}&code_verifier=${verifier}`;
+    `code=${code}&redirect_uri=http://127.0.0.1:${AUTH_PORT}&code_verifier=${verifier}`;
 
   const res = await fetch(AUTH_TOKEN_URL, {
     method: 'POST',
@@ -149,7 +149,7 @@ const stopServer = (): void => {
 };
 
 const handleServerResponse = async (request: http.IncomingMessage, response: http.ServerResponse): Promise<void> => {
-  const urlObj = new URL(`http://localhost:${AUTH_PORT}/${request.url}`);
+  const urlObj = new URL(`http://127.0.0.1:${AUTH_PORT}/${request.url}`);
   const queryState = urlObj.searchParams.get('state');
 
   try {


### PR DESCRIPTION
minor revision to allow new users to login with lofi desktop client. previous code used localhost addresses in the auth.ts file which are no longer compatible with Spotify's dev API requirements (OAuth2.0), this revision replaces those with 127.0.0.1 which is the officially supported address to route API calls. 

One small edit that I suggest before merging the files: in line 20 I had to replace the AUTH_CLIENT_ID = 'insert client ID' with my own from my personal Spotify Dev account. This was just to enable testing on my machine once I compiled the program. It will continue to work just fine if you choose to leave this in the merge, but please note that the CLIENT_ID will no longer be making a call to your team's Spotify dev account. No clue what the implications are here.